### PR TITLE
updated readme to remind calling start function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,14 @@ final hubConnection = HubConnectionBuilder().withUrl(serverUrl, options: httpOpt
 final hubConnection.onclose( (error) => print("Connection Closed"));
 
 ```
+#### 2. Connect to a Hub:
+Calling following method starts handshaking and connects the client to SignalR server
+```c
+await hubConnection.start();
+```
 
 
-#### 2. Calling a Hub function:
+#### 3. Calling a Hub function:
 
 Assuming there is this hub function:
 ```c

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The client can invoke the function by using:
 ```
 
 
-#### 3. Calling a client function:
+#### 4. Calling a client function:
 
 Assuming the server calls a function "aClientProvidedFunction":
 ```c


### PR DESCRIPTION
Hi @soernt,

First of all, thanks for providing this library. It has been really useful for a project I'm working on.

While following the readme steps, I realised that `await hubConnection.start();` missing so wanted to make sure it is mentioned in the setup phase.

Also, I wasn't sure what is the code of conduct and best way to contribute, so please welcome my direct approach and sending the PR straight away 😇