### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/dartio_http_client.dart
+++ b/lib/dartio_http_client.dart
@@ -86,9 +86,9 @@ class DartIOHttpClient extends SignalRHttpClient {
         final isJsonContent =
             contentTypeHeader.indexOf("application/json") != -1;
         if (isJsonContent) {
-          content = await httpResp.transform(utf8.decoder).join();
+          content = await utf8.decoder.bind(httpResp).join();
         } else {
-          content = await httpResp.transform(utf8.decoder).join();
+          content = await utf8.decoder.bind(httpResp).join();
           // When using SSE and the uri has an 'id' query parameter the response is not evaluated, otherwise it is an error.
           if (isStringEmpty(uri.queryParameters['id'])) {
             throw ArgumentError(


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
