### PR TITLE
MessagePack Protocol

### DIFF
--- a/lib/binary_message_format.dart
+++ b/lib/binary_message_format.dart
@@ -1,0 +1,63 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'errors.dart';
+
+class BinaryMessageFormat {
+
+  static Uint8List write(Uint8List output) {
+    var size = output.lengthInBytes;
+    List<int> lenBuffer = [];
+    do {
+      var sizePart = size & 0x7f;
+      size = size >> 7;
+      if (size > 0) {
+        sizePart |= 0x80;
+      }
+      lenBuffer.add(sizePart);
+    }
+    while (size > 0);
+
+    size = output.lengthInBytes;
+
+    var buffer = new Uint8List(lenBuffer.length + size);
+    buffer.setAll(0, lenBuffer);
+    buffer.setAll(lenBuffer.length, output);
+    return buffer;
+  }
+
+  static List<Uint8List> parse(Uint8List input) {
+    final List<Uint8List> result = [];
+    const maxLengthPrefixSize = 5;
+    const numBitsToShift = [0, 7, 14, 21, 28 ];
+
+    for (int offset = 0; offset < input.lengthInBytes; offset++) {
+      int numBytes = 0;
+      int size = 0;
+      int byteRead;
+      do {
+        byteRead = input[offset + numBytes];
+        size = size | ((byteRead & 0x7f) << (numBitsToShift[numBytes]));
+        numBytes++;
+      } while (numBytes < min(maxLengthPrefixSize, input.lengthInBytes - offset) && (byteRead & 0x80) != 0);
+
+      if ((byteRead & 0x80) != 0 && numBytes < maxLengthPrefixSize) {
+        throw new GeneralError("Cannot read message size.");
+      }
+
+      if (numBytes == maxLengthPrefixSize && byteRead > 7) {
+        throw new GeneralError("Messages bigger than 2GB are not supported.");
+      }
+
+      if (input.lengthInBytes >= (offset + numBytes + size)) {
+        result.add(input.sublist(offset + numBytes, offset + numBytes + size));
+      } else {
+        throw new GeneralError("Incomplete message.");
+      }
+
+      offset = offset + numBytes + size;
+    }
+
+    return result;
+  }
+}

--- a/lib/msgpack_hub_protocol.dart
+++ b/lib/msgpack_hub_protocol.dart
@@ -1,0 +1,224 @@
+import 'dart:typed_data';
+
+import 'package:logging/logging.dart';
+import 'package:msgpack2/msgpack2.dart';
+
+import 'errors.dart';
+import 'ihub_protocol.dart';
+import 'itransport.dart';
+import 'binary_message_format.dart';
+
+const String MSGPACK_HUB_PROTOCOL_NAME = "messagepack";
+const int PROTOCOL_VERSION = 1;
+const TransferFormat TRANSFER_FORMAT = TransferFormat.Binary;
+// ignore: non_constant_identifier_names
+Uint8List SERIALIZED_PING_MESSAGE = Uint8List.fromList([0x91, MessageType.Ping.index]);
+
+class MsgpackHubProtocol implements IHubProtocol {
+  // Properties
+
+  @override
+  String get name => MSGPACK_HUB_PROTOCOL_NAME;
+
+  @override
+  int get version => PROTOCOL_VERSION;
+
+  @override
+  TransferFormat get transferFormat => TRANSFER_FORMAT;
+
+  // Methods
+  /// Creates an array of {@link @aspnet/signalr.HubMessage} objects from the specified serialized representation.
+  ///
+  /// A Uint8List containing the serialized representation.
+  /// A logger that will be used to log messages that occur during parsing.
+  ///
+  @override
+  List<HubMessageBase> parseMessages(Object input, Logger logger) {
+    // Only JsonContent is allowed.
+    if (!(input is Uint8List)) {
+      throw new GeneralError(
+          "Invalid input for BIANRY hub protocol. Expected a Uint8List.");
+    }
+
+    final hubMessages = List<HubMessageBase>();
+
+    if (input == null) {
+      return hubMessages;
+    }
+
+    // Parse the messages
+    final messages = BinaryMessageFormat.parse(input);
+
+    for (var message in messages) {
+      HubMessageBase parsedMessage = _parseMessage(message, logger);
+      // Can be null for an unknown message. Unknown message is logged in parseMessage
+      if (parsedMessage != null) {
+        hubMessages.add(parsedMessage);
+      }
+    }
+
+    return hubMessages;
+  }
+
+  HubMessageBase _parseMessage(Uint8List input, Logger logger) {
+    if (input.length == 0) {
+      throw new InvalidPayloadException("Invalid payload.");
+    }
+
+    List properties = deserialize(input);
+    if (properties.length == 0) {
+      throw new InvalidPayloadException("Invalid payload.");
+    }
+
+    final messageType = properties[0];
+
+    switch (MessageType.values[messageType]) {
+      case MessageType.Invocation:
+        return _createInvocationMessage(_readHeaders(properties), properties);
+      case MessageType.StreamItem:
+        return _createStreamItemMessage(_readHeaders(properties), properties);
+      case MessageType.Completion:
+        return _createCompletionMessage(_readHeaders(properties), properties);
+      case MessageType.Ping:
+        return _createPingMessage(properties);
+      case MessageType.Close:
+        return _createCloseMessage(properties);
+      default:
+        // Future protocol changes can add message types, old clients can ignore them
+        logger?.info("Unknown message type '$messageType' ignored.");
+        return null;
+    }
+  }
+
+  /// Writes the specified HubMessage to a string and returns it.
+  ///
+  /// message: The message to write.
+  /// Returns a string containing the serialized representation of the message.
+  ///
+  @override
+  Uint8List writeMessage(HubMessageBase message) {
+    switch (message.type) {
+      case MessageType.Invocation:
+        return _writeInvocation(message as InvocationMessage);
+      case MessageType.StreamInvocation:
+        return _writeStreamInvocation(message as StreamInvocationMessage);
+      case MessageType.StreamItem:
+      case MessageType.Completion:
+        throw new GeneralError("Writing messages of type " + message.type.toString() + " is not supported.");
+      case MessageType.Ping:
+        return BinaryMessageFormat.write(SERIALIZED_PING_MESSAGE);
+      default:
+        throw new GeneralError("Invalid message type.");
+    }
+  }
+
+  HubMessageBase _createCloseMessage(List properties) {
+    // check minimum length to allow protocol to add items to the end of objects in future releases
+    if (properties.length < 2) {
+      throw new InvalidPayloadException("Invalid payload for Close message.");
+    }
+
+    return new CloseMessage(properties[1]);
+  }
+
+  HubMessageBase _createPingMessage(List properties) {
+    // check minimum length to allow protocol to add items to the end of objects in future releases
+    if (properties.length < 1) {
+      throw new InvalidPayloadException("Invalid payload for Ping message.");
+    }
+
+    return new PingMessage();
+  }
+
+  InvocationMessage _createInvocationMessage(
+      MessageHeaders headers, List properties) {
+    // check minimum length to allow protocol to add items to the end of objects in future releases
+    if (properties.length < 5) {
+      throw new InvalidPayloadException("Invalid payload for Invocation message.");
+    }
+
+    return new InvocationMessage(
+        properties[3] as String, properties[4], headers, properties[2]);
+  }
+
+  StreamItemMessage _createStreamItemMessage(
+      MessageHeaders headers, List properties) {
+    // check minimum length to allow protocol to add items to the end of objects in future releases
+    if (properties.length < 4) {
+      throw new InvalidPayloadException("Invalid payload for StreamItem message.");
+    }
+
+    return new StreamItemMessage(properties[3], headers, properties[2]);
+  }
+
+  CompletionMessage _createCompletionMessage(
+      MessageHeaders headers, List properties) {
+    // check minimum length to allow protocol to add items to the end of objects in future releases
+    if (properties.length < 4) {
+      throw new InvalidPayloadException("Invalid payload for Completion message.");
+    }
+
+    const errorResult = 1;
+    const voidResult = 2;
+    const nonVoidResult = 3;
+
+    int resultKind = properties[3];
+
+    if (resultKind != voidResult && properties.length < 5) {
+      throw new GeneralError("Invalid payload for Completion message.");
+    }
+
+    String error;
+    Object result;
+
+    switch (resultKind) {
+      case errorResult:
+        error = properties[4];
+        break;
+      case nonVoidResult:
+        result = properties[4];
+        break;
+    }
+
+    return new CompletionMessage(error, result, headers, properties[2]);
+  }
+
+  Map convertMessageHeadersToMap (MessageHeaders messageHeaders) {
+    Map<String, String> returnObj = new Map();
+    for (var headerName in messageHeaders.names) {
+      returnObj[headerName] = messageHeaders.getHeaderValue(headerName);
+    }
+
+    return returnObj;
+  }
+
+  Uint8List _writeInvocation(InvocationMessage invocationMessage) {
+    var payload = serialize([
+      MessageType.Invocation.index,
+      convertMessageHeadersToMap(invocationMessage.headers),
+      invocationMessage.invocationId,
+      invocationMessage.target,
+      invocationMessage.arguments
+    ]);
+
+    return BinaryMessageFormat.write(payload);
+  }
+
+  Uint8List _writeStreamInvocation(
+      StreamInvocationMessage streamInvocationMessage) {
+    var payload = serialize([
+      MessageType.StreamInvocation.index,
+      convertMessageHeadersToMap(streamInvocationMessage.headers),
+      streamInvocationMessage.invocationId,
+      streamInvocationMessage.target,
+      streamInvocationMessage.arguments
+    ]);
+
+    return BinaryMessageFormat.write(payload);
+  }
+
+  MessageHeaders _readHeaders(List properties) {
+    MessageHeaders headers = properties[1] as MessageHeaders;
+    return headers;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
 
   logging: ^0.11.3+2
   w3c_event_source: ^1.3.0
+  msgpack2: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
There is a new [msgpack](https://github.com/butlermatt/msgpack2) flutter library, so I used this one and implemented the new hub protocol. I'm using it here, on my project, but only for Byte[] encoding/decoding... But should work for other types as well. 

Just follow this table and should work (from msgpack2):

```dart
if (value == null) return encodeNull();
if (value is bool) return encodeBool(value);
if (value is int) return encodeInt(value);
if (value is Float) return encodeFloat(value);
if (value is double) return encodeFloat(value);
if (value is String) return encodeString(value);
if (value is ByteData) return encodeBinary(value);
if (value is List) return encodeArray(value);
if (value is Map) return encodeMap(value);
if (value is ExtensionFormat) return encodeExtension(value);
if (value is DateTime)
```

What I did:
- created a binary message formatter
- created a msgpack hub protocol
- based on msgpack2 and messagepack protocol js version
- converted the Header to a Map type before send the message, worked fine with the Authorization: Bearer...

How to use it:

```dart
final hubConnection = HubConnectionBuilder()
        .withUrl(serverUrl)
        .withHubProtocol(new MsgpackHubProtocol())
        .build();
```
Tested only with ByteData type.