### PR TITLE
#41 Fix the exception for Response Content-Type not supported: [application/json; charset=UTF-8]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.1.7]
+* Fix the exception for: Response Content-Type not supported: [application/json; charset=UTF-8]
+
+## [0.1.6]
+* Merged pull request "Prepare for Uint8List SDK breaking change"
+
 ## [0.1.5]
 * Fix complex object serialization to json.
 

--- a/lib/dartio_http_client.dart
+++ b/lib/dartio_http_client.dart
@@ -83,8 +83,7 @@ class DartIOHttpClient extends SignalRHttpClient {
       if ((httpResp.statusCode >= 200) && (httpResp.statusCode < 300)) {
         Object content;
         final contentTypeHeader = httpResp.headers["Content-Type"];
-        final isJsonContent =
-            contentTypeHeader.indexOf("application/json") != -1;
+        final isJsonContent = contentTypeHeader.indexWhere((header) => header.startsWith("application/json")) != -1;
         if (isJsonContent) {
           content = await utf8.decoder.bind(httpResp).join();
         } else {


### PR DESCRIPTION
Fix the issue number #41 Fix the exception for Response Content-Type not supported: [application/json; charset=UTF-8]